### PR TITLE
Code quality and warning removal

### DIFF
--- a/examples/circle.c
+++ b/examples/circle.c
@@ -22,7 +22,7 @@ int main(void)
 					 &buffer);
 		i = (i + 1) % 360;
 		fbgl_draw_circle_filled(480, 540, 40, 0xFFFFFF, &buffer);
-		usleep(10000);
+		nanosleep((struct timespec[]){ { 0, 10000000 } }, NULL);
 	}
 
 	while (1) {

--- a/examples/framebuf_info.c
+++ b/examples/framebuf_info.c
@@ -1,7 +1,7 @@
 #define FBGL_IMPLEMENTATION
 #include "fbgl.h"
 
-int main(int argc, char *argv[])
+int main(void)
 {
 	fbgl_t buffer;
 	if (fbgl_init("/dev/fb0", &buffer) == -1) {

--- a/examples/line.c
+++ b/examples/line.c
@@ -1,7 +1,7 @@
 #define FBGL_IMPLEMENTATION
 #include "fbgl.h"
 
-int main(int argc, char *argv[])
+int main()
 {
 	fbgl_t buffer;
 	if (fbgl_init("/dev/fb0", &buffer) == -1) {
@@ -15,7 +15,7 @@ int main(int argc, char *argv[])
 	for (int i = 0; i < 1890; i++) {
 		start.x = i;
 		fbgl_draw_line(start, end, 0xFFFFFF, &buffer);
-		usleep(1000); // sleep for 1 millisecond
+		nanosleep((struct timespec[]){ { 0, 10000000 } }, NULL);
 	}
 	fbgl_draw_line(start, end, 0x000000, &buffer);
 

--- a/examples/rectangle.c
+++ b/examples/rectangle.c
@@ -1,7 +1,7 @@
 #define FBGL_IMPLEMENTATION
 #include "fbgl.h"
 
-int main(int argc, char *argv[])
+int main(void)
 {
 	fbgl_t buffer;
 	if (fbgl_init("/dev/fb0", &buffer) == -1) {
@@ -53,7 +53,7 @@ int main(int argc, char *argv[])
 			color_index = 0;
 		}
 
-		usleep(50000); // Delay to make the animation visible (adjust as needed)
+		nanosleep((struct timespec[]){ { 0, (int)5e7 } }, NULL);
 	}
 
 	fbgl_destroy(&buffer);

--- a/examples/red.c
+++ b/examples/red.c
@@ -2,7 +2,7 @@
 #include "fbgl.h"
 #include <stdio.h>
 
-int main(int argc, char *argv[])
+int main(void)
 {
 	fbgl_t fb;
 	fbgl_init("/dev/fb0", &fb);

--- a/examples/text.c
+++ b/examples/text.c
@@ -16,35 +16,35 @@ int save_framebuffer_as_ppm(fbgl_t *fb, const char *filename)
 	}
 
 	// Write PPM header (P6 format - binary RGB)
-        fprintf(fp, "P6\n%u %u\n255\n", fb->width, fb->height);
+	fprintf(fp, "P6\n%u %u\n255\n", fb->width, fb->height);
 
-        // Allocate buffer for pixel data
-        uint8_t* pixel_buffer = malloc(fb->width * fb->height * 3);
-        if (!pixel_buffer) {
+	// Allocate buffer for pixel data
+	uint8_t *pixel_buffer = malloc(fb->width * fb->height * 3);
+	if (!pixel_buffer) {
 		perror("Memory allocation error");
 		fclose(fp);
 		return -1;
 	}
 
 	// Convert framebuffer to RGB
-        for (int32_t y = 0; y < fb->height; y++) {
-            for (int32_t x = 0; x < fb->width; x++) {
-                uint32_t pixel = fb->pixels[y * fb->width + x];
+	for (int32_t y = 0; y < fb->height; y++) {
+		for (int32_t x = 0; x < fb->width; x++) {
+			uint32_t pixel = fb->pixels[y * fb->width + x];
 
-                // Extract RGB components (assuming 32-bit ARGB or RGB)
-                uint8_t r = (pixel >> 16) & 0xFF;
-                uint8_t g = (pixel >> 8) & 0xFF;
-                uint8_t b = pixel & 0xFF;
+			// Extract RGB components (assuming 32-bit ARGB or RGB)
+			uint8_t r = (pixel >> 16) & 0xFF;
+			uint8_t g = (pixel >> 8) & 0xFF;
+			uint8_t b = pixel & 0xFF;
 
-                // Store in buffer for PPM
-                pixel_buffer[(y * fb->width + x) * 3] = r;
-                pixel_buffer[(y * fb->width + x) * 3 + 1] = g;
-                pixel_buffer[(y * fb->width + x) * 3 + 2] = b;
-            }
-        }
+			// Store in buffer for PPM
+			pixel_buffer[(y * fb->width + x) * 3] = r;
+			pixel_buffer[(y * fb->width + x) * 3 + 1] = g;
+			pixel_buffer[(y * fb->width + x) * 3 + 2] = b;
+		}
+	}
 
-        // Write pixel data
-        fwrite(pixel_buffer, 1, fb->width * fb->height * 3, fp);
+	// Write pixel data
+	fwrite(pixel_buffer, 1, fb->width * fb->height * 3, fp);
 
 	// Cleanup
 	free(pixel_buffer);
@@ -76,9 +76,6 @@ int main(int argc, char *argv[])
 	// Text to render
 	const char *text = "Hello, fbgl!";
 
-	// Calculate text width
-	size_t text_width = strlen(text) * 8;
-
 	// Calculate centered position
 	int x = (fb.width - 8) / 2;
 	int y = (fb.height - 16) / 2;
@@ -96,7 +93,7 @@ int main(int argc, char *argv[])
 	// Wait for a bit to show the image
 	size_t framerate = 30 * 30;
 	for (size_t i = 0; i < framerate; i++) {
-		usleep(50000);
+		nanosleep((struct timespec[]){ { 0, (int)5e7 } }, NULL);
 	}
 
 	// Cleanup

--- a/examples/texture.c
+++ b/examples/texture.c
@@ -6,19 +6,25 @@
 
 int main(int argc, char **argv)
 {
-	// Initialize framebuffer
-	fbgl_t framebuffer;
-	if (fbgl_init(NULL, &framebuffer) != 0) {
-		fprintf(stderr, "Failed to initialize framebuffer.\n");
+	if (argc < 2) {
+		fprintf(stderr, "Usage: %s <texture_path>\n", argv[0]);
 		return EXIT_FAILURE;
 	}
 
 	// Load a TGA texture
 	const char *texture_path = argv[1];
+
 	fbgl_tga_texture_t *texture = fbgl_load_tga_texture(texture_path);
 	if (!texture) {
 		fprintf(stderr, "Failed to load texture.\n");
-		fbgl_destroy(&framebuffer);
+
+		return EXIT_FAILURE;
+	}
+
+	// Initialize framebuffer
+	fbgl_t framebuffer;
+	if (fbgl_init(NULL, &framebuffer) != 0) {
+		fprintf(stderr, "Failed to initialize framebuffer.\n");
 		return EXIT_FAILURE;
 	}
 
@@ -55,8 +61,10 @@ int main(int argc, char **argv)
 		    texture_y + texture->height >= framebuffer.height) {
 			dy = -dy; // Reverse vertical direction when hitting the top or bottom edge
 		}
+		nanosleep(
+			(struct timespec[]){ { 0, (int)5e7 } },
+			NULL); // Delay to make the marquee effect visible (adjust as needed)
 
-		usleep(50000); // Delay to make the marquee effect visible (adjust as needed)
 		framesize--;
 	}
 

--- a/examples/texture_show_fps.c
+++ b/examples/texture_show_fps.c
@@ -20,6 +20,12 @@ char *float_to_string(float value)
 
 int main(int argc, char **argv)
 {
+	if (argc < 3) {
+		fprintf(stderr, "Usage: %s <texture_path> <font_path>\n",
+			argv[0]);
+		return EXIT_FAILURE;
+	}
+
 	// Initialize framebuffer
 	fbgl_t framebuffer;
 	if (fbgl_init(NULL, &framebuffer) != 0) {
@@ -78,7 +84,11 @@ int main(int argc, char **argv)
 		fbgl_render_psf1_text(&framebuffer, font, fps, 100, 0,
 				      0xFF0000);
 
-		usleep(50000); // Delay to make the marquee effect visible (adjust as needed)
+		free(fps);
+
+		nanosleep(
+			(struct timespec[]){ { 0, (int)5e7 } },
+			NULL); // Delay to make the marquee effect visible (adjust as needed)
 		framesize--;
 	}
 

--- a/fbgl.h
+++ b/fbgl.h
@@ -97,7 +97,6 @@ typedef struct fbgl_psf1_font {
  */
 static struct timespec previous_frame_time = { 0 };
 
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -137,9 +136,9 @@ void fbgl_draw_rectangle_filled(fbgl_point_t top_left,
 				fbgl_point_t bottom_right, uint32_t color,
 				fbgl_t *fb);
 void fbgl_draw_circle_outline(int x, int y, int radius, uint32_t color,
-    fbgl_t* fb);
+			      fbgl_t *fb);
 void fbgl_draw_circle_filled(int x, int y, int radius, uint32_t color,
-    fbgl_t* fb);
+			     fbgl_t *fb);
 
 /**
  * texture
@@ -166,8 +165,11 @@ void fbgl_render_psf1_text(fbgl_t *fb, fbgl_psf1_font_t *font, const char *text,
  *
  */
 #define FBGL_RGB(r, g, b) ((uint32_t)(((r) << 16) | ((g) << 8) | (b)))
-#define FBGL_RGBA(r, g, b, a) ((uint32_t)(((a) << 24) | ((r) << 16) | ((g) << 8) | (b)))
-#define FBGL_F32RGB_TO_U32(r, g, b) ((uint32_t)(((uint8_t)(r * 255) << 16) | ((uint8_t)(g * 255) << 8) | (uint8_t)(b * 255)))
+#define FBGL_RGBA(r, g, b, a) \
+	((uint32_t)(((a) << 24) | ((r) << 16) | ((g) << 8) | (b)))
+#define FBGL_F32RGB_TO_U32(r, g, b)                                          \
+	((uint32_t)(((uint8_t)(r * 255) << 16) | ((uint8_t)(g * 255) << 8) | \
+		    (uint8_t)(b * 255)))
 #define FBGL_F32RGBA_TO_U32(r, g, b, a) ((uint32_t)(((uint8_t)(a * 255) << 24) | ((uint8_t)(r * 255) << 16) | ((uint8_t)(g * 255) << 8) | (uint8_t)(b * 255))
 
 #ifdef FBGL_IMPLEMENTATION
@@ -342,161 +344,169 @@ void fbgl_draw_rectangle_filled(fbgl_point_t top_left,
 }
 
 void fbgl_draw_circle_outline(int x, int y, int radius, uint32_t color,
-    fbgl_t* fb)
+			      fbgl_t *fb)
 {
-    int f = 1 - radius;
-    int ddF_x = 1;
-    int ddF_y = -2 * radius;
-    int xx = 0;
-    int yy = radius;
+	int f = 1 - radius;
+	int ddF_x = 1;
+	int ddF_y = -2 * radius;
+	int xx = 0;
+	int yy = radius;
 
-    fbgl_put_pixel(x, y + radius, color, fb);
-    fbgl_put_pixel(x, y - radius, color, fb);
-    fbgl_put_pixel(x + radius, y, color, fb);
-    fbgl_put_pixel(x - radius, y, color, fb);
+	fbgl_put_pixel(x, y + radius, color, fb);
+	fbgl_put_pixel(x, y - radius, color, fb);
+	fbgl_put_pixel(x + radius, y, color, fb);
+	fbgl_put_pixel(x - radius, y, color, fb);
 
-    while (xx < yy) {
-        if (f >= 0) {
-            yy--;
-            ddF_y += 2;
-            f += ddF_y;
-        }
-        xx++;
-        ddF_x += 2;
-        f += ddF_x;
+	while (xx < yy) {
+		if (f >= 0) {
+			yy--;
+			ddF_y += 2;
+			f += ddF_y;
+		}
+		xx++;
+		ddF_x += 2;
+		f += ddF_x;
 
-        fbgl_put_pixel(x + xx, y + yy, color, fb);
-        fbgl_put_pixel(x - xx, y + yy, color, fb);
-        fbgl_put_pixel(x + xx, y - yy, color, fb);
-        fbgl_put_pixel(x - xx, y - yy, color, fb);
-        fbgl_put_pixel(x + yy, y + xx, color, fb);
-        fbgl_put_pixel(x - yy, y + xx, color, fb);
-        fbgl_put_pixel(x + yy, y - xx, color, fb);
-        fbgl_put_pixel(x - yy, y - xx, color, fb);
-    }
+		fbgl_put_pixel(x + xx, y + yy, color, fb);
+		fbgl_put_pixel(x - xx, y + yy, color, fb);
+		fbgl_put_pixel(x + xx, y - yy, color, fb);
+		fbgl_put_pixel(x - xx, y - yy, color, fb);
+		fbgl_put_pixel(x + yy, y + xx, color, fb);
+		fbgl_put_pixel(x - yy, y + xx, color, fb);
+		fbgl_put_pixel(x + yy, y - xx, color, fb);
+		fbgl_put_pixel(x - yy, y - xx, color, fb);
+	}
 }
 
-void fbgl_draw_circle_filled(int x, int y, int radius, uint32_t color, fbgl_t* fb)
+void fbgl_draw_circle_filled(int x, int y, int radius, uint32_t color,
+			     fbgl_t *fb)
 {
-    for (int yy = -radius; yy <= radius; ++yy) {
-        int half_width = (int)sqrt(radius * radius - yy * yy);
+	for (int yy = -radius; yy <= radius; ++yy) {
+		int half_width = (int)sqrt(radius * radius - yy * yy);
 
-        int row_start = x - half_width;
-        int row_end = x + half_width;
+		int row_start = x - half_width;
+		int row_end = x + half_width;
 
-        if (y + yy < 0 || y + yy >= fb->height)
-            continue;
-        if (row_start < 0)
-            row_start = 0;
-        if (row_end >= fb->width)
-            row_end = fb->width - 1;
+		if (y + yy < 0 || y + yy >= fb->height)
+			continue;
+		if (row_start < 0)
+			row_start = 0;
+		if (row_end >= fb->width)
+			row_end = fb->width - 1;
 
-        int pixel_offset = (y + yy) * fb->width + row_start;
-        int num_pixels = row_end - row_start + 1;
+		int pixel_offset = (y + yy) * fb->width + row_start;
+		int num_pixels = row_end - row_start + 1;
 
-        uint32_t* row_start_ptr = fb->pixels + pixel_offset;
-        for (int i = 0; i < num_pixels; ++i) {
-            row_start_ptr[i] = color;
-        }
-    }
+		uint32_t *row_start_ptr = fb->pixels + pixel_offset;
+		for (int i = 0; i < num_pixels; ++i) {
+			row_start_ptr[i] = color;
+		}
+	}
 }
 
-fbgl_tga_texture_t* fbgl_load_tga_texture(const char* path)
+fbgl_tga_texture_t *fbgl_load_tga_texture(const char *path)
 {
-    FILE* file = fopen(path, "rb");
-    if (!file) {
-        perror("Unable to open texture file");
-        return NULL;
-    }
+	FILE *file = fopen(path, "rb");
+	if (!file) {
+		perror("Unable to open texture file");
+		return NULL;
+	}
 
-    // TGA header structure
-    uint8_t header[18];
-    if (fread(header, 1, sizeof(header), file) != sizeof(header)) {
-        perror("Error reading TGA header");
-        fclose(file);
-        return NULL;
-    }
+	// TGA header structure
+	uint8_t header[18];
+	if (fread(header, 1, sizeof(header), file) != sizeof(header)) {
+		perror("Error reading TGA header");
+		fclose(file);
+		return NULL;
+	}
 
-    // Allocate texture structure
-    fbgl_tga_texture_t* texture = (fbgl_tga_texture_t*)malloc(
-        sizeof(fbgl_tga_texture_t));
-    if (!texture) {
-        perror("Failed to allocate texture structure");
-        fclose(file);
-        return NULL;
-    }
+	// Allocate texture structure
+	fbgl_tga_texture_t *texture =
+		(fbgl_tga_texture_t *)malloc(sizeof(fbgl_tga_texture_t));
+	if (!texture) {
+		perror("Failed to allocate texture structure");
+		fclose(file);
+		return NULL;
+	}
 
-    // Extract dimensions from header
-    texture->width = header[12] | (header[13] << 8);
-    texture->height = header[14] | (header[15] << 8);
-    uint8_t bits_per_pixel = header[16];
-    uint8_t image_descriptor = header[17];
+	// Extract dimensions from header
+	texture->width = header[12] | (header[13] << 8);
+	texture->height = header[14] | (header[15] << 8);
+	uint8_t bits_per_pixel = header[16];
+	uint8_t image_descriptor = header[17];
 
-    // Verify format support
-    if (bits_per_pixel != 24 && bits_per_pixel != 32) {
-        fprintf(stderr,
-            "Unsupported TGA bit depth: %d (only 24 and 32-bit supported)\n",
-            bits_per_pixel);
-        free(texture);
-        fclose(file);
-        return NULL;
-    }
+	// Verify format support
+	if (bits_per_pixel != 24 && bits_per_pixel != 32) {
+		fprintf(stderr,
+			"Unsupported TGA bit depth: %d (only 24 and 32-bit supported)\n",
+			bits_per_pixel);
+		free(texture);
+		fclose(file);
+		return NULL;
+	}
 
-    // Skip image ID field
-    if (header[0]) {
-        fseek(file, header[0], SEEK_CUR);
-    }
+	// Skip image ID field
+	if (header[0]) {
+		fseek(file, header[0], SEEK_CUR);
+	}
 
-    // Allocate pixel data
-    size_t pixel_count = texture->width * texture->height;
-    texture->data = (uint32_t*)malloc(pixel_count * sizeof(uint32_t));
-    if (!texture->data) {
-        perror("Failed to allocate pixel data");
-        free(texture);
-        fclose(file);
-        return NULL;
-    }
+	// Allocate pixel data
+	size_t pixel_count = texture->width * texture->height;
+	texture->data = (uint32_t *)malloc(pixel_count * sizeof(uint32_t));
+	if (!texture->data) {
+		perror("Failed to allocate pixel data");
+		free(texture);
+		fclose(file);
+		return NULL;
+	}
 
-    // Read pixel data
-    uint8_t* pixel_buffer = (uint8_t*)malloc(bits_per_pixel / 8);
-    if (!pixel_buffer) {
-        perror("Failed to allocate pixel buffer");
-        free(texture->data);
-        free(texture);
-        fclose(file);
-        return NULL;
-    }
+	// Read pixel data
+	uint8_t *pixel_buffer = (uint8_t *)malloc(bits_per_pixel / 8);
+	if (!pixel_buffer) {
+		perror("Failed to allocate pixel buffer");
+		free(texture->data);
+		free(texture);
+		fclose(file);
+		return NULL;
+	}
 
-    // Determine if image is flipped (based on image descriptor)
-    bool bottom_up = !(image_descriptor & 0x20);
+	// Determine if image is flipped (based on image descriptor)
+	bool bottom_up = !(image_descriptor & 0x20);
 
-    for (size_t i = 0; i < pixel_count; i++) {
-        size_t pixel_index = bottom_up ? (texture->height - 1 - (i / texture->width)) * texture->width + (i % texture->width) : i;
+	for (size_t i = 0; i < pixel_count; i++) {
+		size_t pixel_index =
+			bottom_up ?
+				(texture->height - 1 - (i / texture->width)) *
+						texture->width +
+					(i % texture->width) :
+				i;
 
-        if (fread(pixel_buffer, 1, bits_per_pixel / 8, file) != bits_per_pixel / 8) {
-            perror("Error reading pixel data");
-            free(pixel_buffer);
-            free(texture->data);
-            free(texture);
-            fclose(file);
-            return NULL;
-        }
+		if (fread(pixel_buffer, 1, bits_per_pixel / 8, file) !=
+		    bits_per_pixel / 8) {
+			perror("Error reading pixel data");
+			free(pixel_buffer);
+			free(texture->data);
+			free(texture);
+			fclose(file);
+			return NULL;
+		}
 
-        // Convert BGR(A) to RGBA
-        uint32_t pixel = 0xFF000000; // Default alpha to 255
-        pixel |= pixel_buffer[2] << 16; // R
-        pixel |= pixel_buffer[1] << 8; // G
-        pixel |= pixel_buffer[0]; // B
-        if (bits_per_pixel == 32) {
-            pixel = (pixel & 0x00FFFFFF) | (pixel_buffer[3] << 24); // A
-        }
+		// Convert BGR(A) to RGBA
+		uint32_t pixel = 0xFF000000; // Default alpha to 255
+		pixel |= pixel_buffer[2] << 16; // R
+		pixel |= pixel_buffer[1] << 8; // G
+		pixel |= pixel_buffer[0]; // B
+		if (bits_per_pixel == 32) {
+			pixel = (pixel & 0x00FFFFFF) |
+				(pixel_buffer[3] << 24); // A
+		}
 
-        texture->data[pixel_index] = pixel;
-    }
+		texture->data[pixel_index] = pixel;
+	}
 
-    free(pixel_buffer);
-    fclose(file);
-    return texture;
+	free(pixel_buffer);
+	fclose(file);
+	return texture;
 }
 
 void fbgl_destroy_texture(fbgl_tga_texture_t *texture)


### PR DESCRIPTION
Solved all code quality issues, removed dead code.

Correctly freed fps buffer in texture_show_fps.c

Correctly checked for argc size before accessing argv (did not show up in warnings but it's still dangerous)

Reordered some resource acquisition operations in examples in order to avoid framebuffer creation if wrong inputs are specified (we fail first).